### PR TITLE
[nemo-qml-plugin-thumbnailer] Replace separate video thumbnailer package. JB#57202

### DIFF
--- a/rpm/nemo-qml-plugin-thumbnailer-qt5.spec
+++ b/rpm/nemo-qml-plugin-thumbnailer-qt5.spec
@@ -1,6 +1,6 @@
 Name:       nemo-qml-plugin-thumbnailer-qt5
 Summary:    Thumbnail provider plugin for Nemo Mobile
-Version:    1.0.0
+Version:    1.0.7
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-thumbnailer
@@ -11,6 +11,10 @@ BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  sailfish-qdoc-template
+Requires: thumbnaild
+Provides: nemo-qml-plugin-thumbnailer-qt5-video
+Obsoletes: nemo-qml-plugin-thumbnailer-qt5-libav < 0.1.0
+Conflicts: nemo-qml-plugin-thumbnailer-qt5-libav
 
 %description
 %{summary}.


### PR DESCRIPTION
Commit 9695503cb2fa23 removed the use of separate video thumbnailer .so
and started executing a separate executable.

-> Use Provides: for the functionality that's required on some packages,
and here depend on thumbnailerd that includes the executables.