### PR TITLE
[nemo-qml-plugin-thumbnailer] Start thumbnailer thread only when needed. JB#57865

### DIFF
--- a/src/plugin/nemothumbnailitem.cpp
+++ b/src/plugin/nemothumbnailitem.cpp
@@ -370,7 +370,6 @@ NemoThumbnailLoader::NemoThumbnailLoader(QQuickWindow *window)
     connect(window, &QQuickWindow::sceneGraphInvalidated,
                 this, &NemoThumbnailLoader::destroyTextures,
                 Qt::DirectConnection);
-    start();
 }
 
 NemoThumbnailLoader::~NemoThumbnailLoader()
@@ -483,6 +482,8 @@ void NemoThumbnailLoader::updateRequest(NemoThumbnailItem *item, bool identityCh
     prioritizeRequest(item->m_request);
 
     m_waitCondition.wakeOne();
+
+    start();
 }
 
 void NemoThumbnailLoader::cancelRequest(NemoThumbnailItem *item)


### PR DESCRIPTION
E.g. in the case the attached property is used to set maxCost but
there's no thumbnail request ever, the thread is just consuming
resources. Let's start the thread only when there's a thumbnail request.

@rainemak @Tomin1 @jpetrell 