### PR TITLE
Add size sanity checks for thumbnails

### DIFF
--- a/rpm/nemo-qml-plugin-thumbnailer-qt5.spec
+++ b/rpm/nemo-qml-plugin-thumbnailer-qt5.spec
@@ -13,8 +13,6 @@ BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  sailfish-qdoc-template
 Requires: thumbnaild
 Provides: nemo-qml-plugin-thumbnailer-qt5-video
-Obsoletes: nemo-qml-plugin-thumbnailer-qt5-libav < 0.1.0
-Conflicts: nemo-qml-plugin-thumbnailer-qt5-libav
 
 %description
 %{summary}.
@@ -37,11 +35,9 @@ Summary:    Thumbnailer plugin documentation
 
 %build
 %qmake5 "VERSION=%{version}"
-make %{?_smp_mflags}
-
+%make_build
 
 %install
-rm -rf %{buildroot}
 %qmake5_install
 
 # org.nemomobile.thumbnailer legacy import
@@ -49,8 +45,11 @@ mkdir -p %{buildroot}%{_libdir}/qt5/qml/org/nemomobile/thumbnailer/
 ln -sf %{_libdir}/qt5/qml/Nemo/Thumbnailer/libnemothumbnailer.so %{buildroot}%{_libdir}/qt5/qml/org/nemomobile/thumbnailer/
 sed 's/Nemo.Thumbnailer/org.nemomobile.thumbnailer/' < src/plugin/qmldir > %{buildroot}%{_libdir}/qt5/qml/org/nemomobile/thumbnailer/qmldir
 
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
 %files
-%defattr(-,root,root,-)
 %license LICENSE.BSD
 %{_libdir}/libnemothumbnailer-qt5.so.*
 %dir %{_libdir}/qt5/qml/Nemo/Thumbnailer
@@ -64,17 +63,11 @@ sed 's/Nemo.Thumbnailer/org.nemomobile.thumbnailer/' < src/plugin/qmldir > %{bui
 %{_libdir}/qt5/qml/org/nemomobile/thumbnailer/qmldir
 
 %files devel
-%defattr(-,root,root,-)
 %{_libdir}/libnemothumbnailer-qt5.so
 %{_libdir}/libnemothumbnailer-qt5.prl
 %{_includedir}/nemothumbnailer-qt5/*.h
 %{_libdir}/pkgconfig/nemothumbnailer-qt5.pc
 
 %files doc
-%defattr(-,root,root,-)
 %dir %{_datadir}/doc/nemo-qml-plugin-thumbnailer
 %{_datadir}/doc/nemo-qml-plugin-thumbnailer/nemo-qml-plugin-thumbnailer.qch
-
-%post -p /sbin/ldconfig
-
-%postun -p /sbin/ldconfig

--- a/src/lib/nemoimagemetadata.h
+++ b/src/lib/nemoimagemetadata.h
@@ -42,7 +42,6 @@ class QByteArray;
 class NEMO_QML_PLUGIN_THUMBNAILER_EXPORT NemoImageMetadata
 {
 public:
-
     enum Orientation {
         TopLeft = 1,
         TopRight,

--- a/src/lib/nemothumbnailcache.cpp
+++ b/src/lib/nemothumbnailcache.cpp
@@ -348,6 +348,8 @@ QImage NemoThumbnailCache::ThumbnailData::getScaledImage(const QSize &requestedS
     }
 }
 
+static unsigned int MaximumSaneSize = 6000;
+
 NemoThumbnailCache::NemoThumbnailCache(const QString &cachePath)
     : cachePath_(cachePath)
 #ifdef HAS_MLITE5
@@ -360,6 +362,12 @@ NemoThumbnailCache::NemoThumbnailCache(const QString &cachePath)
 {
     if (screenWidth_ > screenHeight_) {
         std::swap(screenWidth_, screenHeight_);
+    }
+
+    if (screenWidth_ > MaximumSaneSize || screenHeight_ > MaximumSaneSize) {
+        qWarning() << "Invalid screen dimensions, capping to" << MaximumSaneSize;
+        screenWidth_ = std::min(screenWidth_, MaximumSaneSize);
+        screenHeight_ = std::min(screenHeight_, MaximumSaneSize);
     }
 
     QDir directory(cachePath_);

--- a/src/lib/nemothumbnailcache.h
+++ b/src/lib/nemothumbnailcache.h
@@ -67,7 +67,8 @@ public:
 
         unsigned size() const;
 
-        QImage getScaledImage(const QSize &requestedSize, bool crop = false, Qt::TransformationMode mode = Qt::FastTransformation) const;
+        QImage getScaledImage(const QSize &requestedSize, bool crop = false,
+                              Qt::TransformationMode mode = Qt::FastTransformation) const;
 
     private:
         QString path_;
@@ -77,23 +78,26 @@ public:
 
     static NemoThumbnailCache *instance();
 
-    ThumbnailData requestThumbnail(const QString &path, const QSize &requestedSize, bool crop, bool unbounded = true, const QString &mimeType = QString());
+    ThumbnailData requestThumbnail(const QString &path, const QSize &requestedSize, bool crop,
+                                   bool unbounded = true, const QString &mimeType = QString());
 
-    ThumbnailData existingThumbnail(const QString &path, const QSize &requestedSize, bool crop, bool unbounded = true) const;
+    ThumbnailData existingThumbnail(const QString &path, const QSize &requestedSize,
+                                    bool crop, bool unbounded = true) const;
 
 protected:
     NemoThumbnailCache(const QString &cachePath);
     virtual ~NemoThumbnailCache();
 
-    virtual ThumbnailData generateThumbnail(const QString &path, const QByteArray &key, int size, bool crop, const QString &mimeType);
+    virtual ThumbnailData generateThumbnail(const QString &path, const QByteArray &key,
+                                            int size, bool crop, const QString &mimeType);
     QString writeCacheFile(const QByteArray &key, const QImage &image);
 
     static QImage readImageThumbnail(
-            QImageReader *reader, const QSize requestedSize, bool crop, Qt::TransformationMode mode);
+            QImageReader *reader, QSize requestedSize, bool crop, Qt::TransformationMode mode);
 
 private:
     inline NemoThumbnailCache::ThumbnailData generateImageThumbnail(
-            const QString &path, const QByteArray &key, const int requestedSize, bool crop);
+            const QString &path, const QByteArray &key, int requestedSize, bool crop);
 
     const QString cachePath_;
     unsigned screenWidth_;

--- a/src/plugin/nemothumbnailitem.cpp
+++ b/src/plugin/nemothumbnailitem.cpp
@@ -54,6 +54,7 @@ int thumbnailerMaxCost()
     return ok ? cost : 1360 * 768 * 3;
 }
 
+int MaximumSaneSize = 10000;
 }
 
 ThumbnailRequest::ThumbnailRequest(NemoThumbnailItem *item, const QString &fileName, uint cacheKey)
@@ -302,7 +303,13 @@ void NemoThumbnailItem::updateThumbnail(bool identityChanged)
 
     Status status = m_request ? m_request->status : Null;
 
-    if (m_source.isLocalFile() && !m_sourceSize.isEmpty())
+    bool valid = m_source.isLocalFile() && !m_sourceSize.isEmpty();
+    if (valid && (m_sourceSize.width() > MaximumSaneSize || m_sourceSize.height() > MaximumSaneSize)) {
+        qDebug() << "Thumbnail source size too big, ignoring update. Size:" << m_sourceSize;
+        valid = false;
+    }
+
+    if (valid)
         m_loader->updateRequest(this, identityChanged);
     else if (m_request)
         m_loader->cancelRequest(this);

--- a/src/plugin/nemothumbnailitem.cpp
+++ b/src/plugin/nemothumbnailitem.cpp
@@ -426,7 +426,10 @@ void NemoThumbnailLoader::updateRequest(NemoThumbnailItem *item, bool identityCh
         const bool crop = item->m_fillMode == NemoThumbnailItem::PreserveAspectCrop;
 
         // Create an identifier for this request's data
-        const uint cacheKey = qHash(crop) ^ qHash(item->m_sourceSize.width()) ^ qHash(item->m_sourceSize.height()) ^ qHash(fileName);
+        const uint cacheKey = qHash(crop)
+                ^ qHash(item->m_sourceSize.width())
+                ^ qHash(item->m_sourceSize.height())
+                ^ qHash(fileName);
 
         item->m_request = m_requestCache.value(cacheKey);
 
@@ -620,7 +623,8 @@ void NemoThumbnailLoader::run()
         locker.unlock();
 
         if (tryCache) {
-            NemoThumbnailCache::ThumbnailData thumbnail = NemoThumbnailCache::instance()->existingThumbnail(fileName, requestedSize, crop);
+            NemoThumbnailCache::ThumbnailData thumbnail
+                    = NemoThumbnailCache::instance()->existingThumbnail(fileName, requestedSize, crop);
             QImage image = thumbnail.getScaledImage(requestedSize, crop);
 
             locker.relock();
@@ -639,7 +643,8 @@ void NemoThumbnailLoader::run()
                 lists[request->priority]->append(request);
             }
         } else {
-            NemoThumbnailCache::ThumbnailData thumbnail = NemoThumbnailCache::instance()->requestThumbnail(fileName, requestedSize, crop, true, mimeType);
+            NemoThumbnailCache::ThumbnailData thumbnail
+                    = NemoThumbnailCache::instance()->requestThumbnail(fileName, requestedSize, crop, true, mimeType);
             QImage image = thumbnail.getScaledImage(requestedSize, crop);
 
             locker.relock();


### PR DESCRIPTION
Most important being the last commit. Evidently it's not that hard to get qml Thumbnail item having temporary size with max ints while layouting.

Some cleanups while at it.